### PR TITLE
client-to-client and client-config-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,15 @@ DNS search domains and many more. Defaults to 'undef'.
 
 Determines if compression should be enabled. Defaults to 'true'.
 
+#### `server_client_to_client`
+
+Enables the communication between clients
+
+#### `server_client_config_dir`
+
+Creates the client config dir folder ccd inside the config directory and
+enables the usage of this config files
+
 #### `server_user`
 
 Determines if privileges should be dropped to user 'nobody' after startup.

--- a/examples/openvpn.yaml
+++ b/examples/openvpn.yaml
@@ -10,6 +10,8 @@ openvpn::key_city: 'Muenster'
 openvpn::server_subnet: '192.168.57.0 255.255.255.0'
 openvpn::server_push:
   - 'route 172.17.0.0 255.255.0.0'
+openvpn::server_client_to_client: false
+openvpn::server_client_config_dir: false
 openvpn::clients_hash:
   'dhoppe':
     mute: undef # workaround to create empty hash

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,6 +13,19 @@ class openvpn::config {
       require => $::openvpn::config_file_require,
     }
   }
+  if $::openvpn::server_client_config_dir {
+    file { "define_${name}_ccd":
+      ensure  => $::openvpn::config_dir_ensure,
+      path    => "$::openvpn::config_dir_path/ccd",
+      owner   => $::openvpn::config_file_owner,
+      group   => $::openvpn::config_file_group,
+      mode    => $::openvpn::config_file_mode,
+      #source  => $::openvpn::config_file_source,
+      #content => $::openvpn::config_file_content,
+      notify  => $::openvpn::config_file_notify,
+      #require => $::openvpn::config_file_require,
+    }
+  }
 
   if $::openvpn::config_file_path {
     exec { 'ca.key':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,7 +51,9 @@ class openvpn (
   $server_dev               = 'tun',
   $server_subnet            = undef,
   $server_push              = undef,
-  $server_compression       = true,
+  $server_client_to_client  = false,
+  $server_client_config_dir = false,
+  $server_compression= true,
   $server_user              = true,
   $server_group             = true,
 ) inherits ::openvpn::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,7 +53,7 @@ class openvpn (
   $server_push              = undef,
   $server_client_to_client  = false,
   $server_client_config_dir = false,
-  $server_compression= true,
+  $server_compression       = true,
   $server_user              = true,
   $server_group             = true,
 ) inherits ::openvpn::params {

--- a/templates/common/etc/openvpn/openvpn.conf.erb
+++ b/templates/common/etc/openvpn/openvpn.conf.erb
@@ -156,6 +156,7 @@ push "<%= value %>"
 # also has a small subnet behind his connecting
 # machine, such as 192.168.40.128/255.255.255.248.
 # First, uncomment out these lines:
+
 ;client-config-dir ccd
 ;route 192.168.40.128 255.255.255.248
 # Then create a file ccd/Thelonious with this line:
@@ -168,7 +169,11 @@ push "<%= value %>"
 # EXAMPLE: Suppose you want to give
 # Thelonious a fixed VPN IP address of 10.9.0.1.
 # First uncomment out these lines:
+<% if scope['::openvpn::server_client_config_dir'] -%>
+client-config-dir ccd
+<% else -%>
 ;client-config-dir ccd
+<% end -%>
 ;route 10.9.0.0 255.255.255.252
 # Then add this line to ccd/Thelonious:
 #   ifconfig-push 10.9.0.1 10.9.0.2
@@ -210,7 +215,11 @@ push "<%= value %>"
 # To force clients to only see the server, you
 # will also need to appropriately firewall the
 # server's TUN/TAP interface.
+<% if scope['::openvpn::server_client-to-client'] -%>
+client-to-client
+<% else -%>
 ;client-to-client
+<% end -%>
 
 # Uncomment this directive if multiple clients
 # might connect with the same certificate/key

--- a/templates/common/etc/openvpn/openvpn.conf.erb
+++ b/templates/common/etc/openvpn/openvpn.conf.erb
@@ -215,7 +215,7 @@ client-config-dir ccd
 # To force clients to only see the server, you
 # will also need to appropriately firewall the
 # server's TUN/TAP interface.
-<% if scope['::openvpn::server_client-to-client'] -%>
+<% if scope['::openvpn::server_client_to_client'] -%>
 client-to-client
 <% else -%>
 ;client-to-client


### PR DESCRIPTION
Hi Dennis,

i got some changes to make client-to-client and client-config-dir configurable by your puppet-openvpn module.

Kind regards from Stralsund ;)